### PR TITLE
Proposition de mise à jour par Gemini : While running the function 'process_list_of_items' of the Python source file "src/utils.py", in case the summarise is requested to be performed for the items retrieved on a source (website or YouTube), the program tries summarising each article using 2 different LLMs, the "primary_model" and then the "secondary_model" if the first fails. However, if both LLMs fail summarising the article due to any reason, the item is excluded from the returned list. Please update the process so that if the item cannot be summarised for any reason (LLM error, timeout or else), the item is still being added to the returned list and later sent to the user's email. For item for which the summarising process failed, please populate the column "summary" with a value that clearly indicates that the process failed to summarise. Please create a branch and a pull request so that I can validate the changes before merging them to the main branch.

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -1396,6 +1396,8 @@ def process_list_of_items(source_name: str,
             except Exception as e:
                 print(f"Failed to summarize content for the item '{item[config['key.json.title']]}' with both models.")
                 print(f"Due to {e}")
+                # If both models fail, set a specific message instead of None
+                summary = "ERROR: The summary could not be generated for this item."
         finally:
             if summary != None:
                 summary.replace("\n", " ")


### PR DESCRIPTION
Cette PR a été générée automatiquement par l'agent Gemini.